### PR TITLE
Judges: SSR initial data to avoid skeleton-only rendering on /judges

### DIFF
--- a/app/judges/JudgesContent.tsx
+++ b/app/judges/JudgesContent.tsx
@@ -39,7 +39,11 @@ interface JudgesResponse {
   has_more: boolean
 }
 
-export default function JudgesContent() {
+interface JudgesContentProps {
+  initialData?: JudgesResponse
+}
+
+export default function JudgesContent({ initialData }: JudgesContentProps) {
   const currentYear = new Date().getFullYear()
   const [recentYearsFilter, setRecentYearsFilter] = useState(RECENT_JUDGE_YEARS)
   const recentDecisionsStartYear = currentYear - (recentYearsFilter - 1)
@@ -51,12 +55,12 @@ export default function JudgesContent() {
   // Initialize search from URL parameter
   const [searchInput, setSearchInput] = useState('')
   const [selectedJurisdiction, setSelectedJurisdiction] = useState('CA')
-  const [judges, setJudges] = useState<JudgeWithDecisions[]>([])
-  const [loading, setLoading] = useState(true)
-  const [initialLoad, setInitialLoad] = useState(true)
-  const [totalCount, setTotalCount] = useState(0)
-  const [currentPage, setCurrentPage] = useState(1)
-  const [hasMore, setHasMore] = useState(false)
+  const [judges, setJudges] = useState<JudgeWithDecisions[]>(initialData?.judges ?? [])
+  const [loading, setLoading] = useState(!initialData)
+  const [initialLoad, setInitialLoad] = useState(!initialData)
+  const [totalCount, setTotalCount] = useState(initialData?.total_count ?? 0)
+  const [currentPage, setCurrentPage] = useState(initialData?.page ?? 1)
+  const [hasMore, setHasMore] = useState(initialData?.has_more ?? false)
   const [onlyWithDecisions, setOnlyWithDecisions] = useState(false)
   
   // State for judge-specific stats
@@ -132,8 +136,12 @@ export default function JudgesContent() {
     : judges
 
   useEffect(() => {
-    fetchJudges(1, true)
-  }, [fetchJudges])
+    // If we have initial data from SSR, don't immediately refetch on mount.
+    // Refetch when user changes filters/search.
+    if (!initialData) {
+      fetchJudges(1, true)
+    }
+  }, [fetchJudges, initialData])
   
   // Fetch judge-specific stats
   useEffect(() => {

--- a/app/judges/page.tsx
+++ b/app/judges/page.tsx
@@ -80,10 +80,25 @@ function JudgesLoading() {
   )
 }
 
-export default function JudgesPage() {
+async function getInitialJudges() {
+  try {
+    const response = await fetch(`/api/judges/list?limit=20&page=1&jurisdiction=CA&include_decisions=true`, {
+      cache: 'force-cache',
+      next: { revalidate: 600 }
+    })
+    if (!response.ok) return null
+    const data = await response.json()
+    return data
+  } catch {
+    return null
+  }
+}
+
+export default async function JudgesPage() {
+  const initialData = await getInitialJudges()
   return (
     <Suspense fallback={<JudgesLoading />}>
-      <JudgesContent />
+      <JudgesContent initialData={initialData || undefined} />
     </Suspense>
   )
 }


### PR DESCRIPTION
- Fetch initial page of judges server-side in app/judges/page.tsx and pass to JudgesContent
- Accept optional initialData in JudgesContent to initialize state, skip initial client fetch
- Keeps client-side fetch for subsequent pages and filter/search changes

This prevents the Judges page from sticking on the Suspense skeleton when hydration is delayed. Once merged, Netlify should deploy and the page will render results immediately.